### PR TITLE
fix: improve permissions parser

### DIFF
--- a/src/engine/Creator.ts
+++ b/src/engine/Creator.ts
@@ -61,10 +61,20 @@ function parseSchemaPermissions(rawPerms: { [key: string]: string[] }, guild?: G
     const guildRoles = guild.roles.cache.map((role) => {
       return { name: role.name, id: role.id }
     })
+    const guildMembers = guild.members.cache.map((member) => {
+      return { name: member.user.username, id: member.id }
+    })
 
     permslist = permslist.map((perm) => {
       perm[1] = perm[1].map((roleCitated) => {
-        const catched = guildRoles.filter(guildRole => guildRole.name === roleCitated)[0]
+
+        // try to catch any role with the role citated in the config file _perms
+        let catched = guildRoles.filter(guildRole => guildRole.name === roleCitated)[0]
+        if (catched)
+          return catched.id
+
+        // if not catched a role, this will try with guild members
+        catched = guildMembers.filter(member => member.name === roleCitated)[0]
         if (catched)
           return catched.id
         return roleCitated

--- a/src/engine/FSParser.ts
+++ b/src/engine/FSParser.ts
@@ -9,8 +9,7 @@ import type { FSRoleConfig } from "./interfaces/FSRole"
 import type { FSGuildConfig } from "./interfaces/FSGuild"
 import { InactiveUserTimeout } from "./interfaces/FSGuild"
 
-async function parseFS(guild: Guild, dir: string) {
-  const serverDir = dir
+async function parseFS(guild: Guild, serverDir: string) {
 
   const channelsDir = path.resolve(serverDir, "channels")
 

--- a/src/engine/ambient.ts
+++ b/src/engine/ambient.ts
@@ -1,0 +1,10 @@
+import fs from 'fs'
+import path from "path"
+const templatesPath = path.resolve("./templates")
+
+function configureAmbient() {
+  if (!fs.existsSync("./templates"))
+    fs.mkdirSync(templatesPath, { recursive: true })
+}
+
+export {configureAmbient,templatesPath}

--- a/src/engine/interfaces/FSChannel.ts
+++ b/src/engine/interfaces/FSChannel.ts
@@ -13,53 +13,57 @@ interface FSChannelConfig {
   hide_threads_after?: HideThreadString
 }
 
-type PermissionsFromSchema =
-  "view_channel" |
-  "create_instant_invite" |
-  "manage_channels" |
-  "add_reactions" |
-  "send_messages" |
-  "send_tts_messages" |
-  "manage_messages" |
-  "embed_links" |
-  "attach_files" |
-  "read_message_history" |
-  "mention_everyone" |
-  "use_external_emojis" |
-  "manage_roles" |
-  "manage_webhooks" |
-  "use_application_commands" |
-  "manage_threads" |
-  "create_public_threads" |
-  "create_private_threads" |
-  "use_external_stickers" |
-  "send_messages_in_threads" |
-  "use_embedded_activities" |
-  "send_voice_messages" |
-  "create_instant_envites" |
-  "kick_members" |
-  "ban_members" |
-  "administrator" |
-  "manage_guild" |
-  "view_audit_log" |
-  "priority_speaker" |
-  "stream" |
-  "view_guild_insights" |
-  "connect" |
-  "speak" |
-  "mute_members" |
-  "deafen_members" |
-  "move_members" |
-  "use_vad" |
-  "change_nickname" |
-  "manage_nicknames" |
-  "manage_emojis_and_stickers" |
-  "manage_guild_expressions" |
-  "request_to_speak" |
-  "manage_events" |
-  "moderate_members" |
-  "view_creator_monetization_analytics" |
-  "use_soundboard" |
-  "use_external_sounds"
+const channelSchemaPermissions = [
+  "view_channel",
+  "create_instant_invite",
+  "manage_channels",
+  "add_reactions",
+  "send_messages",
+  "send_tts_messages",
+  "manage_messages",
+  "embed_links",
+  "attach_files",
+  "read_message_history",
+  "mention_everyone",
+  "use_external_emojis",
+  "manage_roles",
+  "manage_webhooks",
+  "use_application_commands",
+  "manage_threads",
+  "create_public_threads",
+  "create_private_threads",
+  "use_external_stickers",
+  "send_messages_in_threads",
+  "use_embedded_activities",
+  "send_voice_messages",
+  // "create_instant_envites",
+  "kick_members",
+  "ban_members",
+  "administrator",
+  "manage_guild",
+  "view_audit_log",
+  "priority_speaker",
+  "stream",
+  "view_guild_insights",
+  "connect",
+  "speak",
+  "mute_members",
+  "deafen_members",
+  "move_members",
+  "use_vad",
+  "change_nickname",
+  "manage_nicknames",
+  "manage_emojis_and_stickers",
+  "manage_guild_expressions",
+  "request_to_speak",
+  "manage_events",
+  "moderate_members",
+  "view_creator_monetization_analytics",
+  "use_soundboard",
+  "use_external_sounds",
+] as const
 
-export { FSChannelConfig, ChannelType, HideThreadString, PermissionsFromSchema, SlowModeString }
+type ChannelSchemaPermission = typeof channelSchemaPermissions[number];
+
+export type { FSChannelConfig,ChannelSchemaPermission, ChannelType, HideThreadString, SlowModeString }
+export { channelSchemaPermissions }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -2,6 +2,7 @@ import "dotenv/config"
 import process from "node:process"
 import { Client, GatewayIntentBits } from "discord.js"
 import { engineHandler } from "./commands"
+import { configureAmbient } from "./engine/ambient"
 
 const client = new Client({
   intents: [
@@ -22,5 +23,6 @@ client.on("error", (err) => {
 })
 
 engineHandler(client)
+configureAmbient()
 
 client.login(process.env.DISCORD_TOKEN)


### PR DESCRIPTION
- The raw permissions parser now handles user and role permissions, not just roles as before.
- `Denied permissions` are auto included in a permissions parser result.
- The application create the `templates` folder if not exists.